### PR TITLE
Jenkinsfile: set base branch

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -13,4 +13,5 @@ pipelinePythonSCA(
     runUnitTests: true,
     unitTestRunner: 'py.test',
     packages: [".[tests]"],
+    baseBranch: "development",
 )


### PR DESCRIPTION
In order to be able to upload non-dev versions from "development" branch.
